### PR TITLE
feat(CacheFactory): new dispose method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -98,13 +98,17 @@ let createCache = (cacheId, options) => {
     $$id: cacheId,
 
     destroy() {
-      clearInterval(this.$$cacheFlushIntervalId);
-      clearInterval(this.$$recycleFreqId);
       this.removeAll();
       if ($$storage) {
         $$storage().removeItem(`${this.$$prefix}.keys`);
         $$storage().removeItem(this.$$prefix);
       }
+      this.dispose();
+    },
+
+    dispose() {
+      clearInterval(this.$$cacheFlushIntervalId);
+      clearInterval(this.$$recycleFreqId);
       $$storage = null;
       $$data = null;
       $$lruHeap = null;
@@ -830,6 +834,13 @@ CacheFactory.keys = () => _keys(caches);
 CacheFactory.destroy = cacheId => {
   if (caches[cacheId]) {
     caches[cacheId].destroy();
+    delete caches[cacheId];
+  }
+};
+
+CacheFactory.dispose = cacheId => {
+  if (caches[cacheId]) {
+    caches[cacheId].dispose();
     delete caches[cacheId];
   }
 };

--- a/test/unit/Cache/index.dispose.test.js
+++ b/test/unit/Cache/index.dispose.test.js
@@ -1,0 +1,31 @@
+describe('Cache#dispose()', function () {
+  it('should remove the cache from the registry of caches.', function () {
+    var cache = TestCacheFactory('dispose-cache');
+    cache.dispose();
+    try {
+      assert.equal(cache.info(), { size: 0 });
+      fail('should not be able to use a cache after disposing it');
+    } catch (err) {
+
+    }
+    assert.isUndefined(TestCacheFactory.get('dispose-cache'));
+  });
+  it('should not remove items from localStorage when storageMode is used.', function () {
+    var localStorageCache = TestCacheFactory('dispose-lsc', { storageMode: 'localStorage', storagePrefix: 'acc.' });
+    var sessionStorageCache = TestCacheFactory('dispose-ssc', { storageMode: 'sessionStorage' });
+
+    localStorageCache.put('item1', 'value1');
+    sessionStorageCache.put('item1', 'value1');
+
+    var localStoragePrefix = localStorageCache.$$storagePrefix;
+    var sessionStoragePrefix = sessionStorageCache.$$storagePrefix;
+
+    localStorageCache.dispose();
+    sessionStorageCache.dispose();
+
+    assert.equal(JSON.parse(localStorage.getItem(localStoragePrefix + 'dispose-lsc.data.item1')).value, 'value1');
+    assert.equal(localStorage.getItem(localStoragePrefix + 'dispose-lsc.keys'), '["item1"]');
+    assert.equal(JSON.parse(sessionStorage.getItem(sessionStoragePrefix + 'dispose-ssc.data.item1')).value, 'value1');
+    assert.equal(sessionStorage.getItem(sessionStoragePrefix + 'dispose-ssc.keys'), '["item1"]');
+  });
+});


### PR DESCRIPTION
Calling `cache.dispose` will dispose of that cache removing it from the `CacheFactory`; any items
that the cache has added to underlying storage will _not_ be removed
