### PR TITLE
[feature/fix-expiration] order cache instance configuration in setOptions so that maxAge is set before setStorageMode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -641,6 +641,24 @@ function createCache (cacheId, options) {
         this.$$disabled = defaults.disabled
       }
 
+      if ('deleteOnExpire' in cacheOptions) {
+        this.setDeleteOnExpire(cacheOptions.deleteOnExpire, false)
+      } else if (strict) {
+        this.setDeleteOnExpire(defaults.deleteOnExpire, false)
+      }
+
+      if ('recycleFreq' in cacheOptions) {
+        this.setRecycleFreq(cacheOptions.recycleFreq)
+      } else if (strict) {
+        this.setRecycleFreq(defaults.recycleFreq)
+      }
+
+      if ('maxAge' in cacheOptions) {
+        this.setMaxAge(cacheOptions.maxAge)
+      } else if (strict) {
+        this.setMaxAge(defaults.maxAge)
+      }
+
       if ('storageMode' in cacheOptions || 'storageImpl' in cacheOptions) {
         this.setStorageMode(cacheOptions.storageMode || defaults.storageMode, cacheOptions.storageImpl || defaults.storageImpl)
       } else if (strict) {
@@ -663,24 +681,6 @@ function createCache (cacheId, options) {
         this.setCapacity(cacheOptions.capacity)
       } else if (strict) {
         this.setCapacity(defaults.capacity)
-      }
-
-      if ('deleteOnExpire' in cacheOptions) {
-        this.setDeleteOnExpire(cacheOptions.deleteOnExpire, false)
-      } else if (strict) {
-        this.setDeleteOnExpire(defaults.deleteOnExpire, false)
-      }
-
-      if ('maxAge' in cacheOptions) {
-        this.setMaxAge(cacheOptions.maxAge)
-      } else if (strict) {
-        this.setMaxAge(defaults.maxAge)
-      }
-
-      if ('recycleFreq' in cacheOptions) {
-        this.setRecycleFreq(cacheOptions.recycleFreq)
-      } else if (strict) {
-        this.setRecycleFreq(defaults.recycleFreq)
       }
 
       if ('cacheFlushInterval' in cacheOptions) {


### PR DESCRIPTION
`put` call in `setStorageMode` relies on `$$maxAge` being set before. It seems reordering configuration is needed.

Failing scenario before fix:
When I create a cache with a maxAge and passive mode
And I store a data in this cache
And I refresh the page
And I read the stored data
Then the stored data is correctly returned
-> the key exists but stored data is returned as undefined
