### PR TITLE
Name of property is `enabled` in CacheInfo output, not `enable`

### DIFF
--- a/dist/cachefactory.d.ts
+++ b/dist/cachefactory.d.ts
@@ -68,7 +68,7 @@ export interface CacheOptions {
 	cacheFlushInterval?: number;
 	capacity?: number;
 	deleteOnExpire?: DeleteOnExpire;
-	enable?: boolean;
+	enabled?: boolean;
 	maxAge?: number;
 	onExpire?: OnExpireCallback;
 	recycleFreq?: number;


### PR DESCRIPTION
Enabled flag key name is `enabled` not `enable` inside `CacheOptions` when querying cache.info();

Reproduce by simply creating a cache and console logging out cache.info();