### PR TITLE
Info method type overload to allow specific return types of info method

### DIFF
--- a/dist/cachefactory.d.ts
+++ b/dist/cachefactory.d.ts
@@ -1,3 +1,9 @@
+
+interface Info {
+	(key: string | number): ItemInfo;
+	(): CacheInfo;
+}
+
 export class CacheFactory {
 	clearAll(): void;
 	createCache(id: string, options?: CacheOptions): Cache;
@@ -20,7 +26,7 @@ export class Cache {
 	disable(): void;
 	enable(): void;
 	get(key: string|number, options?: GetPutOptions): any;
-	info(key: string|number): CacheInfo|ItemInfo;
+	info: Info;
 	keys(): (string|number)[];
 	keySet(): {[key: string]: string|number};
 	put(key: string|number, value: any, options?: GetPutOptions): any;

--- a/dist/cachefactory.d.ts
+++ b/dist/cachefactory.d.ts
@@ -1,4 +1,3 @@
-
 interface Info {
 	(key: string | number): ItemInfo;
 	(): CacheInfo;


### PR DESCRIPTION
Right now when using info method from Cache the return type is either `ItemInfo` or `CacheInfo`. This change (Info overload interface) will result in a `CacheInfo` return value when the info method is called without an argument and an `ItemInfo` return value when info method is called with an argument.